### PR TITLE
Update license

### DIFF
--- a/license
+++ b/license
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) Vsevolod Strukchinsky <floatdrop@gmail.com> (github.com/floatdrop)
+Copyright (c) 2016 Vsevolod Strukchinsky <floatdrop@gmail.com> (github.com/floatdrop)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
MIT license needs both of year and copyright holder.
Please complete MIT license. We want to use this without legal risk.