### PR TITLE
fix: IE support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const denyList = new Set([
+const _denyList = [
 	'ENOTFOUND',
 	'ENETUNREACH',
 
@@ -31,7 +31,12 @@ const denyList = new Set([
 	'CERT_UNTRUSTED',
 	'CERT_REJECTED',
 	'HOSTNAME_MISMATCH'
-]);
+];
+
+const denyList = new Set();
+_denyList.forEach(function (item) {
+	denyList.add(item);
+});
 
 // TODO: Use `error?.code` when targeting Node.js 14
 export default function isRetryAllowed(error) {


### PR DESCRIPTION
There was a problem using this package in IE as a dependent package of `axios-retry`.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
IE does not support `new Set(iterable)`

So, my web application completely crashed in IE, and I modified it to work only with transpiling by adding syntax supported by IE.